### PR TITLE
compatibility for current ArrayFire and current OpenCV

### DIFF
--- a/af_cv.cpp
+++ b/af_cv.cpp
@@ -38,7 +38,7 @@
 
 
 // mem layout for gpu
-void mat_to_array_(cv::Mat& input, array& output, bool transpose = true) {
+void mat_to_array_(cv::Mat& input, af::array& output, bool transpose = true) {
     const unsigned w = input.cols;
     const unsigned h = input.rows;
     const unsigned channels = input.channels();
@@ -46,74 +46,74 @@ void mat_to_array_(cv::Mat& input, array& output, bool transpose = true) {
     if (channels == 1) {
         // bw
         if (transpose) {
-            output = array(w, h, input.ptr<float>(0)).T();
+            output = af::array(w, h, input.ptr<float>(0)).T();
         } else {
-            output = array(h, w, input.ptr<float>(0));
+            output = af::array(h, w, input.ptr<float>(0));
         }
     } else {
         if (w > 2 && h > 2) {
             // 2,3 channel image
-            array input_ = array(w * channels, h, input.ptr<float>(0));
-            array ind = array(seq(channels - 1, channels, w * channels - 1));
+            af::array input_ = af::array(w * channels, h, input.ptr<float>(0));
+            af::array ind = af::array(af::seq(channels - 1, channels, w * channels - 1));
             if (transpose) {
-                output = array(h, w, channels);
-                gfor(array k, channels) {
-                    output(span, span, k) = input_(ind - k, span).T();
+                output = af::array(h, w, channels);
+                gfor(af::array k, channels) {
+                    output(af::span, af::span, k) = input_(ind - k, af::span).T();
                 }
             } else {
-                output = array(w, h, channels);
-                gfor(array k, channels) {
-                    output(span, span, k) = input_(ind - k, span);
+                output = af::array(w, h, channels);
+                gfor(af::array k, channels) {
+                    output(af::span, af::span, k) = input_(ind - k, af::span);
                 }
             }
         } else {
             if (channels == 3) {
                 // 3 channels
-                std::vector<Mat> rgb; split(input, rgb);
+                std::vector<cv::Mat> rgb; split(input, rgb);
                 if (transpose) {
-                    output = array(h, w, 3);
-                    output(span, span, 0) = array(w, h, rgb[2].ptr<float>(0)).T();
-                    output(span, span, 1) = array(w, h, rgb[1].ptr<float>(0)).T();
-                    output(span, span, 2) = array(w, h, rgb[0].ptr<float>(0)).T();
+                    output = af::array(h, w, 3);
+                    output(af::span, af::span, 0) = af::array(w, h, rgb[2].ptr<float>(0)).T();
+                    output(af::span, af::span, 1) = af::array(w, h, rgb[1].ptr<float>(0)).T();
+                    output(af::span, af::span, 2) = af::array(w, h, rgb[0].ptr<float>(0)).T();
                 } else {
-                    output = array(w, h, 3);
-                    output(span, span, 0) = array(w, h, rgb[2].ptr<float>(0));
-                    output(span, span, 1) = array(w, h, rgb[1].ptr<float>(0));
-                    output(span, span, 2) = array(w, h, rgb[0].ptr<float>(0));
+                    output = af::array(w, h, 3);
+                    output(af::span, af::span, 0) = af::array(w, h, rgb[2].ptr<float>(0));
+                    output(af::span, af::span, 1) = af::array(w, h, rgb[1].ptr<float>(0));
+                    output(af::span, af::span, 2) = af::array(w, h, rgb[0].ptr<float>(0));
                 }
             } else {
                 // 2 channels
-                std::vector<Mat> gb; split(input, gb);
+                std::vector<cv::Mat> gb; split(input, gb);
                 if (transpose) {
-                    output = array(h, w, 2);
-                    output(span, span, 0) = array(w, h, gb[1].ptr<float>(0)).T();
-                    output(span, span, 1) = array(w, h, gb[0].ptr<float>(0)).T();
+                    output = af::array(h, w, 2);
+                    output(af::span, af::span, 0) = af::array(w, h, gb[1].ptr<float>(0)).T();
+                    output(af::span, af::span, 1) = af::array(w, h, gb[0].ptr<float>(0)).T();
                 } else {
-                    output = array(w, h, 2);
-                    output(span, span, 0) = array(w, h, gb[1].ptr<float>(0));
-                    output(span, span, 1) = array(w, h, gb[0].ptr<float>(0));
+                    output = af::array(w, h, 2);
+                    output(af::span, af::span, 0) = af::array(w, h, gb[1].ptr<float>(0));
+                    output(af::span, af::span, 1) = af::array(w, h, gb[0].ptr<float>(0));
                 }
             }
         }
     }
 }
 
-void mat_to_array(const std::vector<Mat>& input, array& output, bool transpose) {
+void mat_to_array(const std::vector<cv::Mat>& input, af::array& output, bool transpose) {
     try {
         int d = input[0].dims;
         int h = input[0].rows;
         int w = input[0].cols;
         if (transpose) {
-            output = array(h, w, input.size());
+            output = af::array(h, w, input.size());
         } else {
-            output = array(w, h, input.size());
+            output = af::array(w, h, input.size());
         }
         for (unsigned i = 0; i < input.size(); i++) {
-            array tmp = mat_to_array(input[i], transpose);
+            af::array tmp = mat_to_array(input[i], transpose);
             switch (d) {
-            case 1: output(span, i) = tmp;
+            case 1: output(af::span, i) = tmp;
                 break;
-            case 2: output(span, span, i) = tmp;
+            case 2: output(af::span, af::span, i) = tmp;
                 break;
             default: throw std::runtime_error(std::string("Only 1 and 2 dimensions supported"));
             }
@@ -123,7 +123,7 @@ void mat_to_array(const std::vector<Mat>& input, array& output, bool transpose) 
     }
 }
 
-void mat_to_array(const cv::Mat& input, array& output, bool transpose) {
+void mat_to_array(const cv::Mat& input, af::array& output, bool transpose) {
     if (input.empty()) { return; }
     cv::Mat tmp;
     if (input.channels() == 1)
@@ -135,8 +135,8 @@ void mat_to_array(const cv::Mat& input, array& output, bool transpose) {
     mat_to_array_(tmp, output, transpose);
 }
 
-array mat_to_array(const cv::Mat& input, bool transpose) {
-    array output;
+af::array mat_to_array(const cv::Mat& input, bool transpose) {
+    af::array output;
     if (input.empty()) { return output; }
     cv::Mat mtmp;
     if (input.channels() == 1)
@@ -151,16 +151,16 @@ array mat_to_array(const cv::Mat& input, bool transpose) {
 
 
 // mem layout for cpu
-void array_to_mat(const array& input_, cv::Mat& output, int type, bool transpose) {
+void array_to_mat(const af::array& input_, cv::Mat& output, int type, bool transpose) {
     const int channels = input_.dims(2);
     int ndims = input_.numdims();
-    array input;
+    af::array input;
     if (transpose) {
         if (channels == 1) { input = input_.T(); }
         else {
             input = zero(channels, input_.dims(1), input_.dims(0));
-            gfor(array ii, channels) {
-                input(channels - ii - 1, span, span) = input_(span, span, ii).T();
+            gfor(af::array ii, channels) {
+                input(channels - ii - 1, af::span, af::span) = input_(af::span, af::span, ii).T();
             }
         }
     } else {
@@ -169,26 +169,26 @@ void array_to_mat(const array& input_, cv::Mat& output, int type, bool transpose
     if(ndims == 1) {
         output = cv::Mat(input.dims(ndims - 1), input.elements(), CV_MAKETYPE(type, channels));
     } else {
-        output = cv::Mat(input.dims(ndims - 1), input.dims(ndims - 2), CV_MAKETYPE(type, channels));
+        output = cv::Mat(input.dims(1), input.dims(0), CV_MAKETYPE(type, channels));
     }
     if (type == CV_32F) {
         float* data = output.ptr<float>(0);
         input.host((void*)data);
     } else if (type == CV_32S) {
         int* data = output.ptr<int>(0);
-        input.as(s32).host((void*)data);
+        input.as(af::dtype::s32).host((void*)data);
     } else if (type == CV_64F) {
         double* data = output.ptr<double>(0);
-        input.as(f64).host((void*)data);
+        input.as(af::dtype::f64).host((void*)data);
     } else if (type == CV_8U) {
         uchar* data = output.ptr<uchar>(0);
-        input.as(b8).host((void*)data);
+        input.as(af::dtype::u8).host((void*)data);
     } else {
         throw std::runtime_error(std::string("array to mat error "));
     }
 }
 
-Mat array_to_mat(const array& input, int type, bool transpose) {
+cv::Mat array_to_mat(const af::array& input, int type, bool transpose) {
     cv::Mat output;
     array_to_mat(input, output, type, transpose);
     return output;
@@ -196,7 +196,7 @@ Mat array_to_mat(const array& input, int type, bool transpose) {
 
 
 // Mat type info
-std::string get_mat_type(const Mat& input) { return get_mat_type(input.type()); }
+std::string get_mat_type(const cv::Mat& input) { return get_mat_type(input.type()); }
 std::string get_mat_type(int input) {
     int numImgTypes = 35; // 7 base types, with five channel options each (none or C1, ..., C4)
     int enum_ints[] =       {CV_8U,  CV_8UC1,  CV_8UC2,  CV_8UC3,  CV_8UC4,
@@ -223,11 +223,11 @@ std::string get_mat_type(int input) {
 
 
 // af-cv vis (grayscale only)
-void imshow(const char* name, const array& in_) {
-    array in;
-    if (in_.dims(2) == 3) { in = colorSpace(in_, AF_GRAY, AF_RGB); }
+void imshow(const char* name, const af::array& in_) {
+    af::array in;
+    if (in_.dims(2) == 3) { in = af::colorSpace(in_, AF_GRAY, AF_RGB); }
     else if (in.dims(2) == 1) { in = in_; }
     else { throw std::runtime_error(std::string("imshow error ")); }
-    Mat tmp = array_to_mat(in);
-    imshow(name, tmp); waitKey(5);
+    cv::Mat tmp = array_to_mat(in);
+    cv::imshow(name, tmp); cv::waitKey(5);
 }

--- a/af_cv.cpp
+++ b/af_cv.cpp
@@ -42,7 +42,7 @@ void mat_to_array_(cv::Mat& input, array& output, bool transpose = true) {
     const unsigned w = input.cols;
     const unsigned h = input.rows;
     const unsigned channels = input.channels();
-    if (channels > 3) { throw std::runtime_error(string("mat to array error ")); }
+    if (channels > 3) { throw std::runtime_error(std::string("mat to array error ")); }
     if (channels == 1) {
         // bw
         if (transpose) {
@@ -69,7 +69,7 @@ void mat_to_array_(cv::Mat& input, array& output, bool transpose = true) {
         } else {
             if (channels == 3) {
                 // 3 channels
-                vector<Mat> rgb; split(input, rgb);
+                std::vector<Mat> rgb; split(input, rgb);
                 if (transpose) {
                     output = array(h, w, 3);
                     output(span, span, 0) = array(w, h, rgb[2].ptr<float>(0)).T();
@@ -83,7 +83,7 @@ void mat_to_array_(cv::Mat& input, array& output, bool transpose = true) {
                 }
             } else {
                 // 2 channels
-                vector<Mat> gb; split(input, gb);
+                std::vector<Mat> gb; split(input, gb);
                 if (transpose) {
                     output = array(h, w, 2);
                     output(span, span, 0) = array(w, h, gb[1].ptr<float>(0)).T();
@@ -98,7 +98,7 @@ void mat_to_array_(cv::Mat& input, array& output, bool transpose = true) {
     }
 }
 
-void mat_to_array(const vector<Mat>& input, array& output, bool transpose) {
+void mat_to_array(const std::vector<Mat>& input, array& output, bool transpose) {
     try {
         int d = input[0].dims;
         int h = input[0].rows;
@@ -115,11 +115,11 @@ void mat_to_array(const vector<Mat>& input, array& output, bool transpose) {
                 break;
             case 2: output(span, span, i) = tmp;
                 break;
-            default: throw std::runtime_error(string("Only 1 and 2 dimensions supported"));
+            default: throw std::runtime_error(std::string("Only 1 and 2 dimensions supported"));
             }
         }
     } catch (const af::exception& ex) {
-        throw std::runtime_error(string("mat to array error "));
+        throw std::runtime_error(std::string("mat to array error "));
     }
 }
 
@@ -166,21 +166,25 @@ void array_to_mat(const array& input_, cv::Mat& output, int type, bool transpose
     } else {
         input = input_;
     }
-    output = cv::Mat(input.dims(ndims - 1), input.dims(ndims - 2), CV_MAKETYPE(type, channels));
+    if(ndims == 1) {
+        output = cv::Mat(input.dims(ndims - 1), input.elements(), CV_MAKETYPE(type, channels));
+    } else {
+        output = cv::Mat(input.dims(ndims - 1), input.dims(ndims - 2), CV_MAKETYPE(type, channels));
+    }
     if (type == CV_32F) {
         float* data = output.ptr<float>(0);
         input.host((void*)data);
     } else if (type == CV_32S) {
         int* data = output.ptr<int>(0);
-        input.as(af::s32).host((void*)data);
+        input.as(s32).host((void*)data);
     } else if (type == CV_64F) {
         double* data = output.ptr<double>(0);
-        input.as(af::f64).host((void*)data);
+        input.as(f64).host((void*)data);
     } else if (type == CV_8U) {
         uchar* data = output.ptr<uchar>(0);
-        input.as(af::b8).host((void*)data);
+        input.as(b8).host((void*)data);
     } else {
-        throw std::runtime_error(string("array to mat error "));
+        throw std::runtime_error(std::string("array to mat error "));
     }
 }
 
@@ -203,7 +207,7 @@ std::string get_mat_type(int input) {
                              CV_32F, CV_32FC1, CV_32FC2, CV_32FC3, CV_32FC4,
                              CV_64F, CV_64FC1, CV_64FC2, CV_64FC3, CV_64FC4
                             };
-    string enum_strings[] = {"CV_8U",  "CV_8UC1",  "CV_8UC2",  "CV_8UC3",  "CV_8UC4",
+    std::string enum_strings[] = {"CV_8U",  "CV_8UC1",  "CV_8UC2",  "CV_8UC3",  "CV_8UC4",
                              "CV_8S",  "CV_8SC1",  "CV_8SC2",  "CV_8SC3",  "CV_8SC4",
                              "CV_16U", "CV_16UC1", "CV_16UC2", "CV_16UC3", "CV_16UC4",
                              "CV_16S", "CV_16SC1", "CV_16SC2", "CV_16SC3", "CV_16SC4",
@@ -221,20 +225,9 @@ std::string get_mat_type(int input) {
 // af-cv vis (grayscale only)
 void imshow(const char* name, const array& in_) {
     array in;
-    if (in_.dims(2) == 3) { in = colorspace(in_, af_gray, af_rgb); }
+    if (in_.dims(2) == 3) { in = colorSpace(in_, AF_GRAY, AF_RGB); }
     else if (in.dims(2) == 1) { in = in_; }
-    else { throw std::runtime_error(string("imshow error ")); }
+    else { throw std::runtime_error(std::string("imshow error ")); }
     Mat tmp = array_to_mat(in);
     imshow(name, tmp); waitKey(5);
 }
-
-
-// Mat stats
-void _mtop(const char* exp, Mat X) {
-    _top(exp, mat_to_array(X));
-}
-void _mstats(const char* exp, Mat X) {
-    _stats(exp, mat_to_array(X));
-}
-
-

--- a/af_cv.hpp
+++ b/af_cv.hpp
@@ -39,24 +39,20 @@
 #include <af/util.h>
 #include <opencv2/opencv.hpp>
 
-using namespace af;
-using namespace cv;
-
-
 // conversion for gpu
 void mat_to_array(const cv::Mat& input, af::array& output, bool transpose = true) ;
-void mat_to_array(const std::vector<Mat>& input, af::array& output, bool transpose = true);
+void mat_to_array(const std::vector<cv::Mat>& input, af::array& output, bool transpose = true);
 af::array mat_to_array(const cv::Mat& input, bool transpose = true) ;
 
 
 // conversion for cpu
 void array_to_mat(const af::array& input, cv::Mat& output, int type = CV_32F, bool transpose = true) ;
-Mat array_to_mat(const af::array& input, int type = CV_32F, bool transpose = true) ;
+cv::Mat array_to_mat(const af::array& input, int type = CV_32F, bool transpose = true) ;
 
 
 // get type of a Mat string
 std::string get_mat_type(int input);
-std::string get_mat_type(const Mat& input);
+std::string get_mat_type(const cv::Mat& input);
 
 
 // visualize af array in opencv

--- a/af_cv.hpp
+++ b/af_cv.hpp
@@ -36,7 +36,7 @@
 
 #include <stdio.h>
 #include <arrayfire.h>
-#include <af/utils.h>
+#include <af/util.h>
 #include <opencv2/opencv.hpp>
 
 using namespace af;
@@ -45,7 +45,7 @@ using namespace cv;
 
 // conversion for gpu
 void mat_to_array(const cv::Mat& input, af::array& output, bool transpose = true) ;
-void mat_to_array(const vector<Mat>& input, af::array& output, bool transpose = true);
+void mat_to_array(const std::vector<Mat>& input, af::array& output, bool transpose = true);
 af::array mat_to_array(const cv::Mat& input, bool transpose = true) ;
 
 
@@ -61,14 +61,6 @@ std::string get_mat_type(const Mat& input);
 
 // visualize af array in opencv
 void imshow(const char* name, const af::array& in) ;
-
-
-// Mat stats
-#define mtop(exp) _mtop(#exp, exp)
-void _mtop(const char* exp, Mat X);
-#define mstats(exp) _mstats(#exp, exp)
-void _mstats(const char* exp, Mat X);
-
 
 // af zeros
 #define zero(...) af::constant(0,##__VA_ARGS__);


### PR DESCRIPTION
With the respect of its creator developer, I send this pull request in order to make this compatible with current versions of ArrayFire and OpenCV (tested on 3.7.0 and 3.4.3, respectively). This pull request includes the following in order to accomplish:
- Stick with std:: library for **std::vector** and **std::string** (in order to provide better compatibility and prevent undesired namespace propagation).
- corrects the name of af/utils.h to **af/util.h** which is how's officially called in ArrayFire.
- updates deprecated colorspace to current **colorSpace**.
- changes af_cspace_t af_gray and af_rgb to **AF_GRAY** and **AF_RGB**, respectivelly (maybe TYPO?)
- Fixes the possibility of crash when using single-dimensional array. On this case, it should consider the number of elements instead ask for nonexistent dim(ndims - 2), which gives segmentation fault error.
- With respect to its creator, I removed "Mat stats" functions definition and declarations. I definitely don't know where _top and _stats came from.

It also solves issue #1

System environment:
*buntu 18.04.1 LTS
OpenCV 3.4.3 
ArrayFire v3.7.0 (CPU|OpenCL, 64-bit Linux, build ef5183d7)